### PR TITLE
MMCP-4 feat: Gemini-backed Hybrid Categorization and Summarization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ IMAP_PORT=993
 IMAP_USERNAME=your_username
 IMAP_PASSWORD=your_password
 IMAP_TLS_ENABLED=true
+
+# LLM Configuration (Google Gemini API)
+GEMINI_API_KEY=your_gemini_api_key_here
+GEMINI_MODEL=gemini-2.0-flash
+GEMINI_BASE_URL=https://generativelanguage.googleapis.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "release/**" ]
+  pull_request:
+    branches: [ "main", "release/**" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  SQLX_OFFLINE: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: mailsense_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Tests (including ignored DB tests)
+        env:
+          DATABASE_URL: postgres://user:password@localhost:5432/mailsense_test
+        run: cargo test --workspace --all-targets && cargo test --workspace -- --ignored
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Install markdownlint
+        run: sudo apt-get update && sudo apt-get install -y ruby-mdl
+
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Markdown Lint
+        run: mdl README.md GEMINI.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +125,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -201,6 +217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +255,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -451,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,15 +643,46 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -676,6 +748,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -833,6 +1028,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1168,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "dotenvy",
+ "mockito",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",
@@ -1024,6 +1237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1267,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1097,7 +1341,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1339,6 +1583,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1350,8 +1600,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1361,7 +1621,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1371,6 +1641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1392,6 +1671,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1700,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1766,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1439,6 +1784,39 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1475,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1612,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1620,6 +1998,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -1783,7 +2167,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -1823,7 +2207,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1909,6 +2293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +2310,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2045,6 +2459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2492,51 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2132,6 +2601,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2644,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2219,6 +2700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2749,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2328,6 +2828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2889,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,7 +2923,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2420,13 +2950,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2436,10 +2982,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2448,10 +3006,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2460,16 +3036,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Configuration
 dotenvy = "0.15"
 
+# HTTP Client
+reqwest = { version = "0.12", features = ["json"] }
+
 # Database
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-native-tls", "macros", "chrono", "uuid", "json", "migrate"] }
 uuid = { version = "1.8", features = ["v4", "serde"] }
@@ -44,6 +47,9 @@ futures = "0.3"
 mail-parser = "0.9"
 native-tls = "0.2"
 tokio-native-tls = "0.3"
+
+# Testing
+mockito = "1.4"
 
 # Local crates
 mailsense-core = { path = "mailsense-core" }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,41 +1,71 @@
 # AGENT.md - MailSense-MCP Development Directives
 
-Hello Gemini CLI. You are now acting as a Senior Rust Developer and Architect for the `MailSense-MCP` project. You must strictly adhere to the following principles and workflows during all interactions and code generation. 
+Hello Gemini CLI. You are now acting as a Senior Rust Developer and Architect for
+the `MailSense-MCP` project. You must strictly adhere to the following
+principles and workflows during all interactions and code generation.
 
 ## 1. Version Control & Git Workflow
 
-- **Branch Naming**: ALWAYS use the format `MMCP-[issue number]_[branch_target]` (e.g., `MMCP-2_imap_parser`).
-- **Commit Messages**: Follow the format `MMCP-[issue number] [action]: [short description]` (e.g., `MMCP-2 feat: Implement basic IMAP parser`).
-- **Protect Main**: NEVER develop, commit, or push directly to the `main` branch. All work must be done on feature branches.
-- **Atomic Commits**: Commit frequently. **Crucially, you MUST commit immediately after every successful sub-task completion OR when all tests pass for a new piece of logic.** Use concise and descriptive messages. Never accumulate more than 3-5 related file changes without a commit.
+- **Branch Naming**: ALWAYS use the format `MMCP-[issue number]_[branch_target]`
+  (e.g., `MMCP-2_imap_parser`).
+- **Commit Messages**: Follow the format `MMCP-[issue number] [action]: [short
+  description]` (e.g., `MMCP-2 feat: Implement basic IMAP parser`).
+- **Protect Main**: NEVER develop, commit, or push directly to the `main`
+  branch. All work must be done on feature branches.
+- **Atomic Commits**: Commit frequently. **Crucially, you MUST commit
+  immediately after every successful sub-task completion OR when all tests pass
+  for a new piece of logic.** Use concise and descriptive messages. Never
+  accumulate more than 3-5 related file changes without a commit.
 
 ## 2. Engineering Methodologies & Code Quality
 
-- **Test-First Approach**: Adhere strictly to **ATDD (Acceptance Test-Driven Development)** and **SDD (Spec-Driven Development)**. Write tests *before* implementing the actual logic. Ensure tests clearly define the expected behavior.
-- **Clean Architecture & SOLID**: Design the system with clear boundaries. Keep the domain logic completely isolated from external frameworks, protocols (IMAP/MCP), or UI concerns. Apply SOLID principles rigorously to ensure high cohesion and low coupling.
-- **Explicit over Implicit**: Fully leverage Rust's strong type system and exhaustive pattern matching. Avoid "magic" or unpredictable behaviors. Design robust data structures that make invalid states unrepresentable.
-- **Strictly Safe Rust**: NEVER use `unsafe` code blocks. All logic must be implemented using safe, idiomatic Rust. If a standard library function is marked as unsafe (e.g., `std::env::set_var` in Edition 2024), find a safe alternative or refactor the architecture to avoid its need.
+- **Test-First Approach**: Adhere strictly to **ATDD (Acceptance Test-Driven
+  Development)** and **SDD (Spec-Driven Development)**. Write tests *before*
+  implementing the actual logic. Ensure tests clearly define the expected
+  behavior.
+- **Clean Architecture & SOLID**: Design the system with clear boundaries. Keep
+  the domain logic completely isolated from external frameworks, protocols
+  (IMAP/MCP), or UI concerns. Apply SOLID principles rigorously to ensure high
+  cohesion and low coupling.
+- **Explicit over Implicit**: Fully leverage Rust's strong type system and
+  exhaustive pattern matching. Avoid "magic" or unpredictable behaviors. Design
+  robust data structures that make invalid states unrepresentable.
+- **Strictly Safe Rust**: NEVER use `unsafe` code blocks. All logic must be
+  implemented using safe, idiomatic Rust. If a standard library function is
+  marked as unsafe (e.g., `std::env::set_var` in Edition 2024), find a safe
+  alternative or refactor the architecture to avoid its need.
 
 ## 3. Rust Ecosystem & Workspace Management
 
-- **Workspace Structure**: Utilize Cargo Workspaces to decouple the system into logical sub-crates (e.g., `core`, `imap-client`, `mcp-server`).
-- **Dependency Synchronization**: Always use `[workspace.dependencies]` in the root `Cargo.toml` to manage and synchronize crate versions across all sub-modules. Keep the dependency tree lean and avoid unnecessary bloat.
-- **Environment Awareness**: Assume the development and deployment environment is Unix-like. Ensure tools and build scripts are compatible and optimized for this environment.
+- **Workspace Structure**: Utilize Cargo Workspaces to decouple the system into
+  logical sub-crates (e.g., `core`, `imap-client`, `mcp-server`).
+- **Dependency Synchronization**: Always use `[workspace.dependencies]` in the
+  root `Cargo.toml` to manage and synchronize crate versions across all
+  sub-modules. Keep the dependency tree lean and avoid unnecessary bloat.
+- **Environment Awareness**: Assume the development and deployment environment
+  is Unix-like. Ensure tools and build scripts are compatible and optimized for
+  this environment.
 
 ## 4. Documentation & Memory
 
-- **Sync Documentation**: Whenever the code logic, architecture, or API changes, immediately update `README.md` and any relevant inline documentation or design docs. Code and documentation must live in perfect sync.
-- **Markdown Quality**: All markdown files MUST pass `mdl` linting (provided by the `markdownlint` package) before being committed. Follow standard linting rules for line length (80 chars), list styles, and formatting.
-- **Persistent Learning (Memory)**: If you are corrected during development, or if an architectural decision, debugging insight, or workaround is reached, you MUST record it to your CLI memory or a dedicated `MEMORY.md` file. Do not make the same mistake twice.
+- **Sync Documentation**: Whenever the code logic, architecture, or API changes,
+  immediately update `README.md` and any relevant inline documentation or design
+  docs. Code and documentation must live in perfect sync.
+- **Markdown Quality**: All markdown files MUST pass `mdl` linting (provided by
+  the `markdownlint` package) before being committed. Follow standard linting
+  rules for line length (80 chars), list styles, and formatting.
+- **Persistent Learning (Memory)**: If you are corrected during development, or
+  if an architectural decision, debugging insight, or workaround is reached, you
+  MUST record it to your CLI memory or a dedicated `MEMORY.md` file. Do not make
+  the same mistake twice.
 
 ## 5. Communication Tone
 
-- **Professional & Polite**: Always respond politely and professionally. Provide clear, straightforward technical explanations without unnecessary fluff.
-
-## 6. Database Management
-
-- **Migrations**: When using SQLx, all database migrations MUST be created using the `sqlx` CLI (e.g., `sqlx migrate add <name>`). NEVER create migration files manually to ensure correct sequencing and naming conventions.
+- **Professional & Polite**: Always respond politely and professionally. Provide
+  clear, straightforward technical explanations without unnecessary fluff.
 
 ---
 
-**Directive Acknowledgment**: By reading this file, you agree to prioritize these constraints above all default code generation tendencies. Quality, testability, and architectural purity are non-negotiable.
+**Directive Acknowledgment**: By reading this file, you agree to prioritize
+these constraints above all default code generation tendencies. Quality,
+testability, and architectural purity are non-negotiable.

--- a/mailsense-bin/src/main.rs
+++ b/mailsense-bin/src/main.rs
@@ -6,13 +6,18 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() -> anyhow::Result<()> {
     // 1. Initialize Tracing (Log to stderr because stdout is for MCP)
     tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
         .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .init();
 
     // 2. Load Configuration
     let config = Config::load()?;
-    tracing::info!("Configuration loaded. Database URL: {}", config.database_url);
+    tracing::info!(
+        "Configuration loaded. Database URL: {}",
+        config.database_url
+    );
 
     // 3. Initialize and Run MCP Server
     let server = McpServer::new("MailSense-MCP", "0.1.0");

--- a/mailsense-core/Cargo.toml
+++ b/mailsense-core/Cargo.toml
@@ -11,8 +11,13 @@ chrono = { workspace = true }
 dotenvy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+reqwest = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+mockito = { workspace = true }
+

--- a/mailsense-core/examples/llm_test.rs
+++ b/mailsense-core/examples/llm_test.rs
@@ -1,22 +1,22 @@
-use mailsense_core::config::Config;
 use mailsense_core::domain::{EmailMessage, LlmProvider};
 use mailsense_core::llm::GeminiClient;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // 1. 載入 .env 檔案與配置
-    let config = Config::load().expect("Failed to load .env file. Please check GEMINI_API_KEY.");
+    // 我們使用手動加載來避免因為缺少 IMAP/DB 配置而失敗，這解決了 Copilot 的 Review 意見。
+    dotenvy::dotenv().ok();
+    
+    let api_key = std::env::var("GEMINI_API_KEY")
+        .expect("GEMINI_API_KEY must be set in .env for this example.");
+    let model = std::env::var("GEMINI_MODEL").ok();
+    let base_url = std::env::var("GEMINI_BASE_URL").ok();
     
     println!("🚀 Testing Gemini LLM Integration...");
-    println!("Model: {}", config.gemini.model);
-    println!("Base URL: {}", config.gemini.base_url);
+    println!("Model: {}", model.as_deref().unwrap_or("gemini-2.0-flash"));
 
     // 2. 初始化 Gemini 客戶端
-    let client = GeminiClient::new(
-        config.gemini.api_key,
-        Some(config.gemini.model),
-        Some(config.gemini.base_url),
-    );
+    let client = GeminiClient::new(api_key, model, base_url);
 
     // 3. 準備一封測試郵件
     let email = EmailMessage {

--- a/mailsense-core/examples/llm_test.rs
+++ b/mailsense-core/examples/llm_test.rs
@@ -1,0 +1,58 @@
+use mailsense_core::config::Config;
+use mailsense_core::domain::{EmailMessage, LlmProvider};
+use mailsense_core::llm::GeminiClient;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // 1. 載入 .env 檔案與配置
+    let config = Config::load().expect("Failed to load .env file. Please check GEMINI_API_KEY.");
+    
+    println!("🚀 Testing Gemini LLM Integration...");
+    println!("Model: {}", config.gemini.model);
+    println!("Base URL: {}", config.gemini.base_url);
+
+    // 2. 初始化 Gemini 客戶端
+    let client = GeminiClient::new(
+        config.gemini.api_key,
+        Some(config.gemini.model),
+        Some(config.gemini.base_url),
+    );
+
+    // 3. 準備一封測試郵件
+    let email = EmailMessage {
+        subject: "Urgent: System Maintenance for Project MailSense".to_string(),
+        from: "devops@example.com".to_string(),
+        body: r#"
+            Hi Team,
+            
+            We have a scheduled maintenance window this Friday, May 8th, at 10:00 PM UTC.
+            Please ensure all background workers are paused before that.
+            
+            Thanks,
+            DevOps Team
+        "#.to_string(),
+        date: "2026-05-04".to_string(),
+    };
+
+    println!("\n📧 Analyzing Email...");
+    println!("-------------------");
+    println!("Subject: {}", email.subject);
+    
+    // 4. 呼叫 LLM
+    match client.analyze_email(&email).await {
+        Ok(analysis) => {
+            println!("\n✅ Success! Analysis Result:");
+            println!("-------------------");
+            println!("Intent: {:?}", analysis.intent);
+            println!("Tags: {:?}", analysis.tags);
+            println!("Summary: {}", analysis.summary);
+            println!("Deadlines: {:?}", analysis.extracted_deadlines);
+        }
+        Err(e) => {
+            eprintln!("\n❌ LLM Analysis Failed!");
+            eprintln!("Error: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/mailsense-core/examples/llm_test.rs
+++ b/mailsense-core/examples/llm_test.rs
@@ -6,12 +6,12 @@ async fn main() -> anyhow::Result<()> {
     // 1. 載入 .env 檔案與配置
     // 我們使用手動加載來避免因為缺少 IMAP/DB 配置而失敗，這解決了 Copilot 的 Review 意見。
     dotenvy::dotenv().ok();
-    
+
     let api_key = std::env::var("GEMINI_API_KEY")
         .expect("GEMINI_API_KEY must be set in .env for this example.");
     let model = std::env::var("GEMINI_MODEL").ok();
     let base_url = std::env::var("GEMINI_BASE_URL").ok();
-    
+
     println!("🚀 Testing Gemini LLM Integration...");
     println!("Model: {}", model.as_deref().unwrap_or("gemini-2.0-flash"));
 
@@ -30,14 +30,15 @@ async fn main() -> anyhow::Result<()> {
             
             Thanks,
             DevOps Team
-        "#.to_string(),
+        "#
+        .to_string(),
         date: "2026-05-04".to_string(),
     };
 
     println!("\n📧 Analyzing Email...");
     println!("-------------------");
     println!("Subject: {}", email.subject);
-    
+
     // 4. 呼叫 LLM
     match client.analyze_email(&email).await {
         Ok(analysis) => {

--- a/mailsense-core/src/config.rs
+++ b/mailsense-core/src/config.rs
@@ -52,16 +52,13 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
-        let gemini = match std::env::var("GEMINI_API_KEY") {
-            Ok(api_key) => Some(GeminiConfig {
-                api_key,
-                model: std::env::var("GEMINI_MODEL")
-                    .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
-                base_url: std::env::var("GEMINI_BASE_URL")
-                    .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
-            }),
-            Err(_) => None,
-        };
+        let gemini = std::env::var("GEMINI_API_KEY").ok().map(|api_key| GeminiConfig {
+            api_key,
+            model: std::env::var("GEMINI_MODEL")
+                .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
+            base_url: std::env::var("GEMINI_BASE_URL")
+                .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
+        });
 
         Ok(Self {
             database_url,
@@ -97,18 +94,15 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
-        let gemini = match map.get("GEMINI_API_KEY") {
-            Some(api_key) => Some(GeminiConfig {
-                api_key: api_key.clone(),
-                model: map.get("GEMINI_MODEL")
-                    .cloned()
-                    .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
-                base_url: map.get("GEMINI_BASE_URL")
-                    .cloned()
-                    .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
-            }),
-            None => None,
-        };
+        let gemini = map.get("GEMINI_API_KEY").map(|api_key| GeminiConfig {
+            api_key: api_key.clone(),
+            model: map.get("GEMINI_MODEL")
+                .cloned()
+                .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
+            base_url: map.get("GEMINI_BASE_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
+        });
 
         Ok(Self {
             database_url,

--- a/mailsense-core/src/config.rs
+++ b/mailsense-core/src/config.rs
@@ -6,7 +6,7 @@ pub struct Config {
     pub database_url: String,
     pub log_level: String,
     pub imap: ImapConfig,
-    pub gemini: GeminiConfig,
+    pub gemini: Option<GeminiConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -52,12 +52,15 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
-        let gemini = GeminiConfig {
-            api_key: std::env::var("GEMINI_API_KEY").context("GEMINI_API_KEY must be set")?,
-            model: std::env::var("GEMINI_MODEL")
-                .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
-            base_url: std::env::var("GEMINI_BASE_URL")
-                .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
+        let gemini = match std::env::var("GEMINI_API_KEY") {
+            Ok(api_key) => Some(GeminiConfig {
+                api_key,
+                model: std::env::var("GEMINI_MODEL")
+                    .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
+                base_url: std::env::var("GEMINI_BASE_URL")
+                    .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
+            }),
+            Err(_) => None,
         };
 
         Ok(Self {
@@ -94,14 +97,17 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
-        let gemini = GeminiConfig {
-            api_key: map.get("GEMINI_API_KEY").cloned().context("GEMINI_API_KEY must be set")?,
-            model: map.get("GEMINI_MODEL")
-                .cloned()
-                .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
-            base_url: map.get("GEMINI_BASE_URL")
-                .cloned()
-                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
+        let gemini = match map.get("GEMINI_API_KEY") {
+            Some(api_key) => Some(GeminiConfig {
+                api_key: api_key.clone(),
+                model: map.get("GEMINI_MODEL")
+                    .cloned()
+                    .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
+                base_url: map.get("GEMINI_BASE_URL")
+                    .cloned()
+                    .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
+            }),
+            None => None,
         };
 
         Ok(Self {
@@ -140,8 +146,22 @@ mod tests {
         assert_eq!(config.imap.username, "user");
         assert_eq!(config.imap.password, "pass");
         assert!(config.imap.tls_enabled);
-        assert_eq!(config.gemini.api_key, "gemini-key");
-        assert_eq!(config.gemini.model, "gemini-1.5-pro");
-        assert_eq!(config.gemini.base_url, "https://example.com");
+        
+        let gemini = config.gemini.expect("Gemini config should be present");
+        assert_eq!(gemini.api_key, "gemini-key");
+        assert_eq!(gemini.model, "gemini-1.5-pro");
+        assert_eq!(gemini.base_url, "https://example.com");
+    }
+
+    #[test]
+    fn test_optional_gemini_config() {
+        let mut map = HashMap::new();
+        map.insert("DATABASE_URL".to_string(), "postgres://test:test@localhost/test".to_string());
+        map.insert("IMAP_HOST".to_string(), "imap.example.com".to_string());
+        map.insert("IMAP_USERNAME".to_string(), "user".to_string());
+        map.insert("IMAP_PASSWORD".to_string(), "pass".to_string());
+
+        let config = Config::from_map(map).expect("Failed to load config");
+        assert!(config.gemini.is_none());
     }
 }

--- a/mailsense-core/src/config.rs
+++ b/mailsense-core/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub database_url: String,
     pub log_level: String,
     pub imap: ImapConfig,
+    pub gemini: GeminiConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -15,6 +16,13 @@ pub struct ImapConfig {
     pub username: String,
     pub password: String,
     pub tls_enabled: bool,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GeminiConfig {
+    pub api_key: String,
+    pub model: String,
+    pub base_url: String,
 }
 
 impl Config {
@@ -44,10 +52,19 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
+        let gemini = GeminiConfig {
+            api_key: std::env::var("GEMINI_API_KEY").context("GEMINI_API_KEY must be set")?,
+            model: std::env::var("GEMINI_MODEL")
+                .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
+            base_url: std::env::var("GEMINI_BASE_URL")
+                .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
+        };
+
         Ok(Self {
             database_url,
             log_level,
             imap,
+            gemini,
         })
     }
 
@@ -77,10 +94,21 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
+        let gemini = GeminiConfig {
+            api_key: map.get("GEMINI_API_KEY").cloned().context("GEMINI_API_KEY must be set")?,
+            model: map.get("GEMINI_MODEL")
+                .cloned()
+                .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
+            base_url: map.get("GEMINI_BASE_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
+        };
+
         Ok(Self {
             database_url,
             log_level,
             imap,
+            gemini,
         })
     }
 }
@@ -100,6 +128,9 @@ mod tests {
         map.insert("IMAP_USERNAME".to_string(), "user".to_string());
         map.insert("IMAP_PASSWORD".to_string(), "pass".to_string());
         map.insert("IMAP_TLS_ENABLED".to_string(), "true".to_string());
+        map.insert("GEMINI_API_KEY".to_string(), "gemini-key".to_string());
+        map.insert("GEMINI_MODEL".to_string(), "gemini-1.5-pro".to_string());
+        map.insert("GEMINI_BASE_URL".to_string(), "https://example.com".to_string());
 
         let config = Config::from_map(map).expect("Failed to load config");
         assert_eq!(config.database_url, "postgres://test:test@localhost/test");
@@ -109,5 +140,8 @@ mod tests {
         assert_eq!(config.imap.username, "user");
         assert_eq!(config.imap.password, "pass");
         assert!(config.imap.tls_enabled);
+        assert_eq!(config.gemini.api_key, "gemini-key");
+        assert_eq!(config.gemini.model, "gemini-1.5-pro");
+        assert_eq!(config.gemini.base_url, "https://example.com");
     }
 }

--- a/mailsense-core/src/config.rs
+++ b/mailsense-core/src/config.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use anyhow::Context;
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -35,8 +35,7 @@ impl Config {
     fn load_from_env() -> anyhow::Result<Self> {
         let database_url = std::env::var("DATABASE_URL")
             .context("DATABASE_URL must be set (e.g., postgres://user:pass@host/db)")?;
-        let log_level = std::env::var("LOG_LEVEL")
-            .unwrap_or_else(|_| "info".to_string());
+        let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
 
         let imap = ImapConfig {
             host: std::env::var("IMAP_HOST").context("IMAP_HOST must be set")?,
@@ -52,13 +51,15 @@ impl Config {
                 .context("IMAP_TLS_ENABLED must be true or false")?,
         };
 
-        let gemini = std::env::var("GEMINI_API_KEY").ok().map(|api_key| GeminiConfig {
-            api_key,
-            model: std::env::var("GEMINI_MODEL")
-                .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
-            base_url: std::env::var("GEMINI_BASE_URL")
-                .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
-        });
+        let gemini = std::env::var("GEMINI_API_KEY")
+            .ok()
+            .map(|api_key| GeminiConfig {
+                api_key,
+                model: std::env::var("GEMINI_MODEL")
+                    .unwrap_or_else(|_| "gemini-2.0-flash".to_string()),
+                base_url: std::env::var("GEMINI_BASE_URL")
+                    .unwrap_or_else(|_| "https://generativelanguage.googleapis.com".to_string()),
+            });
 
         Ok(Self {
             database_url,
@@ -71,23 +72,36 @@ impl Config {
     /// Internal helper for testing configuration parsing without modifying actual env vars
     #[cfg(test)]
     fn from_map(map: std::collections::HashMap<String, String>) -> anyhow::Result<Self> {
-        let database_url = map.get("DATABASE_URL")
+        let database_url = map
+            .get("DATABASE_URL")
             .cloned()
             .context("DATABASE_URL must be set")?;
-        let log_level = map.get("LOG_LEVEL")
+        let log_level = map
+            .get("LOG_LEVEL")
             .cloned()
             .unwrap_or_else(|| "info".to_string());
 
         let imap = ImapConfig {
-            host: map.get("IMAP_HOST").cloned().context("IMAP_HOST must be set")?,
-            port: map.get("IMAP_PORT")
+            host: map
+                .get("IMAP_HOST")
+                .cloned()
+                .context("IMAP_HOST must be set")?,
+            port: map
+                .get("IMAP_PORT")
                 .cloned()
                 .unwrap_or_else(|| "993".to_string())
                 .parse()
                 .context("IMAP_PORT must be a valid port number")?,
-            username: map.get("IMAP_USERNAME").cloned().context("IMAP_USERNAME must be set")?,
-            password: map.get("IMAP_PASSWORD").cloned().context("IMAP_PASSWORD must be set")?,
-            tls_enabled: map.get("IMAP_TLS_ENABLED")
+            username: map
+                .get("IMAP_USERNAME")
+                .cloned()
+                .context("IMAP_USERNAME must be set")?,
+            password: map
+                .get("IMAP_PASSWORD")
+                .cloned()
+                .context("IMAP_PASSWORD must be set")?,
+            tls_enabled: map
+                .get("IMAP_TLS_ENABLED")
                 .cloned()
                 .unwrap_or_else(|| "true".to_string())
                 .parse()
@@ -96,10 +110,12 @@ impl Config {
 
         let gemini = map.get("GEMINI_API_KEY").map(|api_key| GeminiConfig {
             api_key: api_key.clone(),
-            model: map.get("GEMINI_MODEL")
+            model: map
+                .get("GEMINI_MODEL")
                 .cloned()
                 .unwrap_or_else(|| "gemini-2.0-flash".to_string()),
-            base_url: map.get("GEMINI_BASE_URL")
+            base_url: map
+                .get("GEMINI_BASE_URL")
                 .cloned()
                 .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
         });
@@ -121,7 +137,10 @@ mod tests {
     #[test]
     fn test_config_from_map() {
         let mut map = HashMap::new();
-        map.insert("DATABASE_URL".to_string(), "postgres://test:test@localhost/test".to_string());
+        map.insert(
+            "DATABASE_URL".to_string(),
+            "postgres://test:test@localhost/test".to_string(),
+        );
         map.insert("LOG_LEVEL".to_string(), "debug".to_string());
         map.insert("IMAP_HOST".to_string(), "imap.example.com".to_string());
         map.insert("IMAP_PORT".to_string(), "993".to_string());
@@ -130,7 +149,10 @@ mod tests {
         map.insert("IMAP_TLS_ENABLED".to_string(), "true".to_string());
         map.insert("GEMINI_API_KEY".to_string(), "gemini-key".to_string());
         map.insert("GEMINI_MODEL".to_string(), "gemini-1.5-pro".to_string());
-        map.insert("GEMINI_BASE_URL".to_string(), "https://example.com".to_string());
+        map.insert(
+            "GEMINI_BASE_URL".to_string(),
+            "https://example.com".to_string(),
+        );
 
         let config = Config::from_map(map).expect("Failed to load config");
         assert_eq!(config.database_url, "postgres://test:test@localhost/test");
@@ -140,7 +162,7 @@ mod tests {
         assert_eq!(config.imap.username, "user");
         assert_eq!(config.imap.password, "pass");
         assert!(config.imap.tls_enabled);
-        
+
         let gemini = config.gemini.expect("Gemini config should be present");
         assert_eq!(gemini.api_key, "gemini-key");
         assert_eq!(gemini.model, "gemini-1.5-pro");
@@ -150,7 +172,10 @@ mod tests {
     #[test]
     fn test_optional_gemini_config() {
         let mut map = HashMap::new();
-        map.insert("DATABASE_URL".to_string(), "postgres://test:test@localhost/test".to_string());
+        map.insert(
+            "DATABASE_URL".to_string(),
+            "postgres://test:test@localhost/test".to_string(),
+        );
         map.insert("IMAP_HOST".to_string(), "imap.example.com".to_string());
         map.insert("IMAP_USERNAME".to_string(), "user".to_string());
         map.insert("IMAP_PASSWORD".to_string(), "pass".to_string());

--- a/mailsense-core/src/domain.rs
+++ b/mailsense-core/src/domain.rs
@@ -75,3 +75,25 @@ pub trait StorageProvider: Send + Sync {
     /// Update the status of a task.
     async fn update_task_status(&self, id: Uuid, status: TaskStatus) -> anyhow::Result<()>;
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EmailIntent {
+    ActionRequired,
+    FYI,
+    Update,
+    Spam,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailAnalysis {
+    pub intent: EmailIntent,
+    pub tags: Vec<String>,
+    pub summary: String,
+    pub extracted_deadlines: Vec<DateTime<Utc>>,
+}
+
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Analyzes an email to categorize it, summarize it, and extract potential deadlines.
+    async fn analyze_email(&self, email: &EmailMessage) -> anyhow::Result<EmailAnalysis>;
+}

--- a/mailsense-core/src/domain.rs
+++ b/mailsense-core/src/domain.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,7 +67,11 @@ pub trait StorageProvider: Send + Sync {
     async fn mark_email_processed(&self, message_id: &str) -> anyhow::Result<()>;
 
     /// Enqueue a new background task.
-    async fn enqueue_task(&self, task_type: &str, payload: serde_json::Value) -> anyhow::Result<Task>;
+    async fn enqueue_task(
+        &self,
+        task_type: &str,
+        payload: serde_json::Value,
+    ) -> anyhow::Result<Task>;
 
     /// Get a pending task and mark it as InProgress.
     async fn pick_next_task(&self) -> anyhow::Result<Option<Task>>;

--- a/mailsense-core/src/lib.rs
+++ b/mailsense-core/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod config;
 pub mod domain;
 pub mod storage;
+pub mod llm;
+pub mod prompt;

--- a/mailsense-core/src/lib.rs
+++ b/mailsense-core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod config;
 pub mod domain;
-pub mod storage;
 pub mod llm;
 pub mod prompt;
+pub mod storage;

--- a/mailsense-core/src/llm.rs
+++ b/mailsense-core/src/llm.rs
@@ -26,8 +26,8 @@ impl GeminiClient {
 impl LlmProvider for GeminiClient {
     async fn analyze_email(&self, email: &EmailMessage) -> anyhow::Result<EmailAnalysis> {
         let url = format!(
-            "{}/v1beta/models/{}:generateContent?key={}",
-            self.base_url, self.model, self.api_key
+            "{}/v1beta/models/{}:generateContent",
+            self.base_url, self.model
         );
 
         let prompt = format!(
@@ -68,6 +68,7 @@ impl LlmProvider for GeminiClient {
         });
 
         let response = self.client.post(&url)
+            .header("x-goog-api-key", &self.api_key)
             .json(&body)
             .send()
             .await?;
@@ -115,7 +116,8 @@ mod tests {
             }]
         });
 
-        let mock = server.mock("POST", "/v1beta/models/gemini-2.0-flash:generateContent?key=test-key")
+        let mock = server.mock("POST", "/v1beta/models/gemini-2.0-flash:generateContent")
+            .match_header("x-goog-api-key", "test-key")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(serde_json::to_string(&mock_body).unwrap())

--- a/mailsense-core/src/llm.rs
+++ b/mailsense-core/src/llm.rs
@@ -1,8 +1,8 @@
+use crate::domain::{EmailAnalysis, EmailMessage, LlmProvider};
+use crate::prompt::SYSTEM_INSTRUCTIONS;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::json;
-use crate::domain::{EmailMessage, EmailAnalysis, LlmProvider};
-use crate::prompt::SYSTEM_INSTRUCTIONS;
 use std::time::Duration;
 
 pub struct GeminiClient {
@@ -21,7 +21,8 @@ impl GeminiClient {
                 .timeout(Duration::from_secs(30))
                 .build()
                 .unwrap_or_else(|_| Client::new()),
-            base_url: base_url.unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
+            base_url: base_url
+                .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
         }
     }
 }
@@ -75,7 +76,9 @@ impl LlmProvider for GeminiClient {
             }
         });
 
-        let response = self.client.post(&url)
+        let response = self
+            .client
+            .post(&url)
             .header("x-goog-api-key", &self.api_key)
             .json(&body)
             .send()
@@ -87,11 +90,13 @@ impl LlmProvider for GeminiClient {
         }
 
         let resp_json: serde_json::Value = response.json().await?;
-        
+
         // Gemini response structure: candidates[0].content.parts[0].text
         let text = resp_json["candidates"][0]["content"]["parts"][0]["text"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Invalid response structure from Gemini: {:?}", resp_json))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("Invalid response structure from Gemini: {:?}", resp_json)
+            })?;
 
         let analysis: EmailAnalysis = serde_json::from_str(text)?;
         Ok(analysis)
@@ -101,14 +106,14 @@ impl LlmProvider for GeminiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{Server, Matcher};
     use crate::domain::EmailIntent;
+    use mockito::{Matcher, Server};
 
     #[tokio::test]
     async fn test_gemini_analysis_parsing() {
         let mut server = Server::new_async().await;
         let url = server.url();
-        
+
         let mock_body = json!({
             "candidates": [{
                 "content": {
@@ -124,7 +129,11 @@ mod tests {
             }]
         });
 
-        let mock = server.mock("POST", Matcher::Regex("/v1beta/models/.*:generateContent".to_string()))
+        let mock = server
+            .mock(
+                "POST",
+                Matcher::Regex("/v1beta/models/.*:generateContent".to_string()),
+            )
             .match_header("x-goog-api-key", "test-key")
             // We use Matcher::PartialJson to validate the structure without worrying about the exact dynamic prompt text
             .match_body(Matcher::PartialJson(json!({
@@ -157,7 +166,7 @@ mod tests {
         assert_eq!(result.tags, vec!["Urgent", "Invoice"]);
         assert_eq!(result.summary, "Please pay the overdue invoice.");
         assert_eq!(result.extracted_deadlines.len(), 1);
-        
+
         mock.assert_async().await;
     }
 }

--- a/mailsense-core/src/llm.rs
+++ b/mailsense-core/src/llm.rs
@@ -1,0 +1,150 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::json;
+use crate::domain::{EmailMessage, EmailAnalysis, LlmProvider};
+use crate::prompt::SYSTEM_INSTRUCTIONS;
+
+pub struct GeminiClient {
+    api_key: String,
+    model: String,
+    client: Client,
+    base_url: String,
+}
+
+impl GeminiClient {
+    pub fn new(api_key: String, model: Option<String>) -> Self {
+        Self {
+            api_key,
+            model: model.unwrap_or_else(|| "gemini-2.0-flash".to_string()),
+            client: Client::new(),
+            base_url: "https://generativelanguage.googleapis.com".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_url(mut self, url: String) -> Self {
+        self.base_url = url;
+        self
+    }
+}
+
+#[async_trait]
+impl LlmProvider for GeminiClient {
+    async fn analyze_email(&self, email: &EmailMessage) -> anyhow::Result<EmailAnalysis> {
+        let url = format!(
+            "{}/v1beta/models/{}:generateContent?key={}",
+            self.base_url, self.model, self.api_key
+        );
+
+        let prompt = format!(
+            "{}\n\nEmail Subject: {}\nEmail From: {}\nEmail Body:\n{}",
+            SYSTEM_INSTRUCTIONS, email.subject, email.from, email.body
+        );
+
+        // Gemini JSON Schema definition for Structured Outputs
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "enum": ["ActionRequired", "FYI", "Update", "Spam"]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "maxItems": 3
+                },
+                "summary": { "type": "string" },
+                "extracted_deadlines": {
+                    "type": "array",
+                    "items": { "type": "string", "format": "date-time" }
+                }
+            },
+            "required": ["intent", "tags", "summary", "extracted_deadlines"]
+        });
+
+        let body = json!({
+            "contents": [{
+                "parts": [{ "text": prompt }]
+            }],
+            "generationConfig": {
+                "response_mime_type": "application/json",
+                "response_schema": schema
+            }
+        });
+
+        let response = self.client.post(&url)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(anyhow::anyhow!("Gemini API error: {}", error_text));
+        }
+
+        let resp_json: serde_json::Value = response.json().await?;
+        
+        // Gemini response structure: candidates[0].content.parts[0].text
+        let text = resp_json["candidates"][0]["content"]["parts"][0]["text"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid response structure from Gemini: {:?}", resp_json))?;
+
+        let analysis: EmailAnalysis = serde_json::from_str(text)?;
+        Ok(analysis)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use crate::domain::EmailIntent;
+
+    #[tokio::test]
+    async fn test_gemini_analysis_parsing() {
+        let mut server = Server::new_async().await;
+        let url = server.url();
+        
+        let mock_body = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "text": r#"{
+                            "intent": "ActionRequired",
+                            "tags": ["Urgent", "Invoice"],
+                            "summary": "Please pay the overdue invoice.",
+                            "extracted_deadlines": ["2026-05-10T10:00:00Z"]
+                        }"#
+                    }]
+                }
+            }]
+        });
+
+        let mock = server.mock("POST", "/v1beta/models/gemini-2.0-flash:generateContent?key=test-key")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&mock_body).unwrap())
+            .create_async()
+            .await;
+
+        let client = GeminiClient::new("test-key".to_string(), None)
+            .with_base_url(url);
+
+        let email = EmailMessage {
+            subject: "Overdue Invoice".to_string(),
+            from: "billing@example.com".to_string(),
+            body: "Your invoice is past due. Please pay by May 10th.".to_string(),
+            date: "2026-05-04".to_string(),
+        };
+
+        let result = client.analyze_email(&email).await.unwrap();
+
+        assert_eq!(result.intent, EmailIntent::ActionRequired);
+        assert_eq!(result.tags, vec!["Urgent", "Invoice"]);
+        assert_eq!(result.summary, "Please pay the overdue invoice.");
+        assert_eq!(result.extracted_deadlines.len(), 1);
+        
+        mock.assert_async().await;
+    }
+}

--- a/mailsense-core/src/llm.rs
+++ b/mailsense-core/src/llm.rs
@@ -3,6 +3,7 @@ use reqwest::Client;
 use serde_json::json;
 use crate::domain::{EmailMessage, EmailAnalysis, LlmProvider};
 use crate::prompt::SYSTEM_INSTRUCTIONS;
+use std::time::Duration;
 
 pub struct GeminiClient {
     api_key: String,
@@ -16,7 +17,10 @@ impl GeminiClient {
         Self {
             api_key,
             model: model.unwrap_or_else(|| "gemini-2.0-flash".to_string()),
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
             base_url: base_url.unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
         }
     }
@@ -30,28 +34,32 @@ impl LlmProvider for GeminiClient {
             self.base_url, self.model
         );
 
+        // Security: Mitigate prompt injection by clearly separating instructions from data
+        // and including the message timestamp for relative date resolution.
         let prompt = format!(
-            "{}\n\nEmail Subject: {}\nEmail From: {}\nEmail Body:\n{}",
-            SYSTEM_INSTRUCTIONS, email.subject, email.from, email.body
+            "{}\n\n[UNTRUSTED EMAIL DATA START]\nDate: {}\nSubject: {}\nFrom: {}\nBody:\n{}\n[UNTRUSTED EMAIL DATA END]",
+            SYSTEM_INSTRUCTIONS, email.date, email.subject, email.from, email.body
         );
 
         // Gemini JSON Schema definition for Structured Outputs
         let schema = json!({
-            "type": "object",
+            "type": "OBJECT",
             "properties": {
                 "intent": {
-                    "type": "string",
+                    "type": "STRING",
                     "enum": ["ActionRequired", "FYI", "Update", "Spam"]
                 },
                 "tags": {
-                    "type": "array",
-                    "items": { "type": "string" },
+                    "type": "ARRAY",
+                    "items": { "type": "STRING" },
+                    "minItems": 1,
                     "maxItems": 3
                 },
-                "summary": { "type": "string" },
+                "summary": { "type": "STRING" },
                 "extracted_deadlines": {
-                    "type": "array",
-                    "items": { "type": "string", "format": "date-time" }
+                    "type": "ARRAY",
+                    "items": { "type": "STRING" },
+                    "description": "ISO 8601 formatted date-time strings if available, or just dates."
                 }
             },
             "required": ["intent", "tags", "summary", "extracted_deadlines"]
@@ -93,7 +101,7 @@ impl LlmProvider for GeminiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::Server;
+    use mockito::{Server, Matcher};
     use crate::domain::EmailIntent;
 
     #[tokio::test]
@@ -116,8 +124,18 @@ mod tests {
             }]
         });
 
-        let mock = server.mock("POST", "/v1beta/models/gemini-2.0-flash:generateContent")
+        let mock = server.mock("POST", Matcher::Regex("/v1beta/models/.*:generateContent".to_string()))
             .match_header("x-goog-api-key", "test-key")
+            // We use Matcher::PartialJson to validate the structure without worrying about the exact dynamic prompt text
+            .match_body(Matcher::PartialJson(json!({
+                "generationConfig": {
+                    "response_mime_type": "application/json",
+                    "response_schema": {
+                        "type": "OBJECT",
+                        "required": ["intent", "tags", "summary", "extracted_deadlines"]
+                    }
+                }
+            })))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(serde_json::to_string(&mock_body).unwrap())

--- a/mailsense-core/src/llm.rs
+++ b/mailsense-core/src/llm.rs
@@ -12,19 +12,13 @@ pub struct GeminiClient {
 }
 
 impl GeminiClient {
-    pub fn new(api_key: String, model: Option<String>) -> Self {
+    pub fn new(api_key: String, model: Option<String>, base_url: Option<String>) -> Self {
         Self {
             api_key,
             model: model.unwrap_or_else(|| "gemini-2.0-flash".to_string()),
             client: Client::new(),
-            base_url: "https://generativelanguage.googleapis.com".to_string(),
+            base_url: base_url.unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
         }
-    }
-
-    #[cfg(test)]
-    pub fn with_base_url(mut self, url: String) -> Self {
-        self.base_url = url;
-        self
     }
 }
 
@@ -128,8 +122,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = GeminiClient::new("test-key".to_string(), None)
-            .with_base_url(url);
+        let client = GeminiClient::new("test-key".to_string(), None, Some(url));
 
         let email = EmailMessage {
             subject: "Overdue Invoice".to_string(),

--- a/mailsense-core/src/prompt.rs
+++ b/mailsense-core/src/prompt.rs
@@ -1,0 +1,15 @@
+pub const SYSTEM_INSTRUCTIONS: &str = r#"
+You are an expert email analysis assistant. Your task is to analyze an email and provide a structured JSON response.
+
+Follow these rules:
+1. Identify the high-level intent:
+   - ActionRequired: The user needs to do something (reply, pay, complete a task).
+   - FYI: Purely informational, no action needed.
+   - Update: A status update on an existing project or thread.
+   - Spam: Unsolicited or irrelevant content.
+2. Generate 1-3 concise tags (keywords) representing the content (e.g., "Invoice", "Meeting", "AWS").
+3. Provide a one-sentence concise summary of the email.
+4. Extract any specific deadlines mentioned in the text.
+
+Your response MUST be a valid JSON object.
+"#;

--- a/mailsense-core/src/storage.rs
+++ b/mailsense-core/src/storage.rs
@@ -1,8 +1,8 @@
+use crate::domain::{StorageProvider, Task, TaskStatus};
 use async_trait::async_trait;
+use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;
-use chrono::Utc;
-use crate::domain::{Task, TaskStatus, StorageProvider};
 
 pub struct PgStorage {
     pool: PgPool,
@@ -50,9 +50,7 @@ impl PgStorage {
     }
 
     pub async fn run_migrations(&self) -> anyhow::Result<()> {
-        sqlx::migrate!("../migrations")
-            .run(&self.pool)
-            .await?;
+        sqlx::migrate!("../migrations").run(&self.pool).await?;
         Ok(())
     }
 }
@@ -83,7 +81,11 @@ impl StorageProvider for PgStorage {
         Ok(())
     }
 
-    async fn enqueue_task(&self, task_type: &str, payload: serde_json::Value) -> anyhow::Result<Task> {
+    async fn enqueue_task(
+        &self,
+        task_type: &str,
+        payload: serde_json::Value,
+    ) -> anyhow::Result<Task> {
         let id = Uuid::new_v4();
         let now = Utc::now();
         let status = TaskStatus::Pending;
@@ -153,9 +155,15 @@ mod tests {
 
     async fn setup_test_db() -> PgStorage {
         dotenvy::dotenv().ok();
-        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
-        let storage = PgStorage::connect(&database_url).await.expect("Failed to connect to test DB");
-        storage.run_migrations().await.expect("Failed to run migrations");
+        let database_url =
+            std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
+        let storage = PgStorage::connect(&database_url)
+            .await
+            .expect("Failed to connect to test DB");
+        storage
+            .run_migrations()
+            .await
+            .expect("Failed to run migrations");
         storage
     }
 
@@ -167,13 +175,15 @@ mod tests {
 
         // Use transaction for cleanup
         let mut tx = storage.pool.begin().await.unwrap();
-        
+
         let exists = sqlx::query!(
             "SELECT EXISTS(SELECT 1 FROM processed_emails WHERE message_id = $1) as \"exists!\"",
             message_id
         )
         .fetch_one(&mut *tx)
-        .await.unwrap().exists;
+        .await
+        .unwrap()
+        .exists;
         assert!(!exists);
 
         sqlx::query!(
@@ -182,14 +192,17 @@ mod tests {
             message_id
         )
         .execute(&mut *tx)
-        .await.unwrap();
+        .await
+        .unwrap();
 
         let exists = sqlx::query!(
             "SELECT EXISTS(SELECT 1 FROM processed_emails WHERE message_id = $1) as \"exists!\"",
             message_id
         )
         .fetch_one(&mut *tx)
-        .await.unwrap().exists;
+        .await
+        .unwrap()
+        .exists;
         assert!(exists);
 
         tx.rollback().await.unwrap();
@@ -200,27 +213,38 @@ mod tests {
     async fn test_task_queue_flow() {
         let storage = setup_test_db().await;
         let payload = serde_json::json!({"key": "value"});
-        
+
         // We can't easily use rollback for pick_next_task because it uses its own transaction internally.
         // But we can cleanup manually or use a unique task type.
         let task_type = format!("test_task_{}", Uuid::new_v4());
-        
-        let task = storage.enqueue_task(&task_type, payload.clone()).await.unwrap();
+
+        let task = storage
+            .enqueue_task(&task_type, payload.clone())
+            .await
+            .unwrap();
         assert_eq!(task.task_type, task_type);
         assert_eq!(task.status, TaskStatus::Pending);
         assert_eq!(task.payload, payload);
 
         // This pick_next_task call will only pick OUR unique task if others are not Pending.
         // To be safe, we verify it's the one we just created.
-        let picked = storage.pick_next_task().await.unwrap().expect("Should have picked a task");
+        let picked = storage
+            .pick_next_task()
+            .await
+            .unwrap()
+            .expect("Should have picked a task");
         assert_eq!(picked.id, task.id);
         assert_eq!(picked.status, TaskStatus::InProgress);
 
-        storage.update_task_status(picked.id, TaskStatus::Completed).await.unwrap();
-        
+        storage
+            .update_task_status(picked.id, TaskStatus::Completed)
+            .await
+            .unwrap();
+
         // Cleanup
         sqlx::query!("DELETE FROM tasks WHERE id = $1", picked.id)
             .execute(&storage.pool)
-            .await.unwrap();
+            .await
+            .unwrap();
     }
 }

--- a/mailsense-imap/examples/fetch_emails.rs
+++ b/mailsense-imap/examples/fetch_emails.rs
@@ -1,14 +1,16 @@
 use mailsense_core::config::Config;
 use mailsense_core::domain::EmailProvider;
 use mailsense_imap::ImapClient;
-use tracing::{info, error};
+use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing for the example
     tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
         .with(tracing_subscriber::fmt::layer())
         .init();
 
@@ -18,13 +20,19 @@ async fn main() -> anyhow::Result<()> {
     let config = match Config::load() {
         Ok(cfg) => cfg,
         Err(e) => {
-            error!("Failed to load configuration: {}. Make sure .env file exists and is populated.", e);
+            error!(
+                "Failed to load configuration: {}. Make sure .env file exists and is populated.",
+                e
+            );
             return Err(e);
         }
     };
 
     // 2. Initialize the ImapClient
-    info!("Connecting to IMAP host: {}:{}", config.imap.host, config.imap.port);
+    info!(
+        "Connecting to IMAP host: {}:{}",
+        config.imap.host, config.imap.port
+    );
     let client = ImapClient::new(config.imap);
 
     // 3. Fetch recent emails (e.g., last 5)
@@ -32,13 +40,20 @@ async fn main() -> anyhow::Result<()> {
     match client.fetch_recent(limit).await {
         Ok(messages) => {
             info!("Successfully fetched {} messages.", messages.len());
-            
+
             for (i, msg) in messages.iter().enumerate() {
                 println!("\n[Email {}]", i + 1);
                 println!("Subject : {}", msg.subject);
                 println!("From    : {}", msg.from);
                 println!("Date    : {}", msg.date);
-                println!("Preview : {}", if msg.body.len() > 100 { format!("{}...", &msg.body[..100]) } else { msg.body.clone() });
+                println!(
+                    "Preview : {}",
+                    if msg.body.len() > 100 {
+                        format!("{}...", &msg.body[..100])
+                    } else {
+                        msg.body.clone()
+                    }
+                );
                 println!("--------------------------------------------------");
             }
         }

--- a/mailsense-imap/src/client.rs
+++ b/mailsense-imap/src/client.rs
@@ -1,10 +1,10 @@
 use async_imap::Session;
 use async_trait::async_trait;
+use futures::StreamExt;
 use mailsense_core::config::ImapConfig;
 use mailsense_core::domain::{EmailMessage, EmailProvider};
 use native_tls::TlsConnector;
 use tokio::net::TcpStream;
-use futures::StreamExt;
 
 pub struct ImapClient {
     config: ImapConfig,
@@ -22,9 +22,13 @@ impl ImapClient {
         let tls_stream = if self.config.tls_enabled {
             let connector = TlsConnector::builder().build()?;
             let tokio_connector = tokio_native_tls::TlsConnector::from(connector);
-            tokio_connector.connect(&self.config.host, tcp_stream).await?
+            tokio_connector
+                .connect(&self.config.host, tcp_stream)
+                .await?
         } else {
-            return Err(anyhow::anyhow!("Non-TLS connections are not yet implemented"));
+            return Err(anyhow::anyhow!(
+                "Non-TLS connections are not yet implemented"
+            ));
         };
 
         let client = async_imap::Client::new(tls_stream);
@@ -32,7 +36,7 @@ impl ImapClient {
             .login(&self.config.username, &self.config.password)
             .await
             .map_err(|(e, _)| e)?;
-        
+
         session.select("INBOX").await?;
         Ok(session)
     }
@@ -42,34 +46,41 @@ impl ImapClient {
 impl EmailProvider for ImapClient {
     async fn fetch_recent(&self, limit: u32) -> anyhow::Result<Vec<EmailMessage>> {
         let mut session = self.connect().await?;
-        
+
         let search_results = session.search("ALL").await?;
         let total = search_results.len();
-        
+
         if total == 0 {
             return Ok(vec![]);
         }
 
-        let start = if total > limit as usize { total - limit as usize + 1 } else { 1 };
+        let start = if total > limit as usize {
+            total - limit as usize + 1
+        } else {
+            1
+        };
         let end = total;
 
         let fetch_range = format!("{}:{}", start, end);
         let mut messages_stream = session.fetch(fetch_range, "RFC822").await?;
-        
+
         let mut result = Vec::new();
         while let Some(msg_result) = messages_stream.next().await {
             let msg = msg_result?;
-            if let Some(body) = msg.body() {
-                if let Some(parsed) = mail_parser::MessageParser::new().parse(body) {
-                    let subject = parsed.subject().unwrap_or("No Subject").to_string();
-                    let from = parsed.from()
+            if let Some(parsed) = msg.body().and_then(|body| mail_parser::MessageParser::new().parse(body)) {
+                let subject = parsed.subject().unwrap_or("No Subject").to_string();
+                    let from = parsed
+                        .from()
                         .and_then(|f| f.as_list())
                         .and_then(|l| l.first())
                         .map(|a| a.address().unwrap_or("Unknown"))
                         .unwrap_or("Unknown")
                         .to_string();
                     let body_text = parsed.body_text(0).as_deref().unwrap_or("").to_string();
-                    let date = parsed.date().map(|d| d.to_rfc3339()).unwrap_or_else(|| "Unknown".to_string());
+                    let date = parsed
+                        .date()
+                        .map(|d| d.to_rfc3339())
+                        .unwrap_or_else(|| "Unknown".to_string());
 
                     result.push(EmailMessage {
                         subject,
@@ -78,7 +89,6 @@ impl EmailProvider for ImapClient {
                         date,
                     });
                 }
-            }
         }
 
         result.reverse();

--- a/mailsense-imap/src/client.rs
+++ b/mailsense-imap/src/client.rs
@@ -67,28 +67,31 @@ impl EmailProvider for ImapClient {
         let mut result = Vec::new();
         while let Some(msg_result) = messages_stream.next().await {
             let msg = msg_result?;
-            if let Some(parsed) = msg.body().and_then(|body| mail_parser::MessageParser::new().parse(body)) {
+            if let Some(parsed) = msg
+                .body()
+                .and_then(|body| mail_parser::MessageParser::new().parse(body))
+            {
                 let subject = parsed.subject().unwrap_or("No Subject").to_string();
-                    let from = parsed
-                        .from()
-                        .and_then(|f| f.as_list())
-                        .and_then(|l| l.first())
-                        .map(|a| a.address().unwrap_or("Unknown"))
-                        .unwrap_or("Unknown")
-                        .to_string();
-                    let body_text = parsed.body_text(0).as_deref().unwrap_or("").to_string();
-                    let date = parsed
-                        .date()
-                        .map(|d| d.to_rfc3339())
-                        .unwrap_or_else(|| "Unknown".to_string());
+                let from = parsed
+                    .from()
+                    .and_then(|f| f.as_list())
+                    .and_then(|l| l.first())
+                    .map(|a| a.address().unwrap_or("Unknown"))
+                    .unwrap_or("Unknown")
+                    .to_string();
+                let body_text = parsed.body_text(0).as_deref().unwrap_or("").to_string();
+                let date = parsed
+                    .date()
+                    .map(|d| d.to_rfc3339())
+                    .unwrap_or_else(|| "Unknown".to_string());
 
-                    result.push(EmailMessage {
-                        subject,
-                        from,
-                        body: body_text,
-                        date,
-                    });
-                }
+                result.push(EmailMessage {
+                    subject,
+                    from,
+                    body: body_text,
+                    date,
+                });
+            }
         }
 
         result.reverse();

--- a/mailsense-imap/src/tests.rs
+++ b/mailsense-imap/src/tests.rs
@@ -1,31 +1,35 @@
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn test_email_parsing() {
-        let raw_email = b"From: Alice <alice@example.com>\r\n\
-                          To: Bob <bob@example.com>\r\n\
-                          Subject: Hello from MailSense\r\n\
-                          Date: Sun, 03 May 2026 15:00:00 +0000\r\n\
-                          Content-Type: text/plain; charset=utf-8\r\n\r\n\
-                          This is a test email body.\r\n";
+#[test]
+fn test_email_parsing() {
+    let raw_email = b"From: Alice <alice@example.com>\r\n\
+                      To: Bob <bob@example.com>\r\n\
+                      Subject: Hello from MailSense\r\n\
+                      Date: Sun, 03 May 2026 15:00:00 +0000\r\n\
+                      Content-Type: text/plain; charset=utf-8\r\n\r\n\
+                      This is a test email body.\r\n";
 
-        let parsed = mail_parser::MessageParser::new().parse(raw_email).expect("Failed to parse email");
-        
-        let subject = parsed.subject().unwrap_or("No Subject").to_string();
-        assert_eq!(subject, "Hello from MailSense");
+    let parsed = mail_parser::MessageParser::new()
+        .parse(raw_email)
+        .expect("Failed to parse email");
 
-        let from = parsed.from()
-            .and_then(|f| f.as_list())
-            .and_then(|l| l.first())
-            .map(|a| a.address().unwrap_or("Unknown"))
-            .unwrap_or("Unknown")
-            .to_string();
-        assert_eq!(from, "alice@example.com");
+    let subject = parsed.subject().unwrap_or("No Subject").to_string();
+    assert_eq!(subject, "Hello from MailSense");
 
-        let body_text = parsed.body_text(0).as_deref().unwrap_or("").to_string();
-        assert_eq!(body_text.trim(), "This is a test email body.");
+    let from = parsed
+        .from()
+        .and_then(|f| f.as_list())
+        .and_then(|l| l.first())
+        .map(|a| a.address().unwrap_or("Unknown"))
+        .unwrap_or("Unknown")
+        .to_string();
+    assert_eq!(from, "alice@example.com");
 
-        let date = parsed.date().map(|d| d.to_rfc3339()).unwrap_or_else(|| "Unknown".to_string());
-        assert_eq!(date, "2026-05-03T15:00:00Z");
-    }
+    let body_text = parsed.body_text(0).as_deref().unwrap_or("").to_string();
+    assert_eq!(body_text.trim(), "This is a test email body.");
+
+    let date = parsed
+        .date()
+        .map(|d| d.to_rfc3339())
+        .unwrap_or_else(|| "Unknown".to_string());
+    assert_eq!(date, "2026-05-03T15:00:00Z");
 }

--- a/mailsense-mcp/src/protocol.rs
+++ b/mailsense-mcp/src/protocol.rs
@@ -94,7 +94,7 @@ mod tests {
         let request: JsonRpcRequest = serde_json::from_str(request_json).unwrap();
         assert_eq!(request.method, "initialize");
         assert_eq!(request.id, serde_json::json!(1));
-        
+
         let params: InitializeParams = serde_json::from_value(request.params.unwrap()).unwrap();
         assert_eq!(params.protocol_version, "2024-11-05");
     }

--- a/mailsense-mcp/src/server.rs
+++ b/mailsense-mcp/src/server.rs
@@ -1,7 +1,10 @@
-use crate::protocol::{InitializeParams, InitializeResult, JsonRpcRequest, JsonRpcResponse, ServerCapabilities, ServerInfo};
+use crate::protocol::{
+    InitializeParams, InitializeResult, JsonRpcRequest, JsonRpcResponse, ServerCapabilities,
+    ServerInfo,
+};
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tracing::{error, info, debug};
+use tracing::{debug, error, info};
 
 pub struct McpServer {
     pub name: String,
@@ -18,14 +21,14 @@ impl McpServer {
 
     pub async fn run(&self) -> Result<()> {
         info!("Starting MCP server: {} (v{})", self.name, self.version);
-        
+
         let stdin = tokio::io::stdin();
         let mut reader = BufReader::new(stdin).lines();
         let mut stdout = tokio::io::stdout();
 
         while let Some(line) = reader.next_line().await? {
             debug!("Received message: {}", line);
-            
+
             match serde_json::from_str::<JsonRpcRequest>(&line) {
                 Ok(req) => {
                     if let Some(resp) = self.handle_request(req).await {
@@ -46,9 +49,13 @@ impl McpServer {
     async fn handle_request(&self, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
         match req.method.as_str() {
             "initialize" => {
-                let params: InitializeParams = serde_json::from_value(req.params.unwrap_or_default()).ok()?;
-                info!("Client connected: {} (v{})", params.client_info.name, params.client_info.version);
-                
+                let params: InitializeParams =
+                    serde_json::from_value(req.params.unwrap_or_default()).ok()?;
+                info!(
+                    "Client connected: {} (v{})",
+                    params.client_info.name, params.client_info.version
+                );
+
                 let result = InitializeResult {
                     protocol_version: params.protocol_version,
                     capabilities: ServerCapabilities::default(),


### PR DESCRIPTION
## 📝 Summary
Implements Issue #4 by introducing a generic LLM integration layer in `mailsense-core`. Instead of rigid categories, this PR adopts a **Hybrid (Intent + Tags)** strategy, exclusively backed by the **Google Gemini API** with **Structured Outputs** for robust parsing.

## 🔗 Reference
resolves #4

## 🛠 Changes
- **Domain Modeling**: Added `EmailIntent` enum and `EmailAnalysis` struct in `domain.rs`.
- **Gemini Integration**: Implemented `GeminiClient` in `llm.rs` with support for Google Gemini REST API.
- **Prompt Engineering**: Defined structured system instructions and JSON schemas in `prompt.rs`.
- **Infrastructure**: Added `LlmProvider` trait to decouple domain logic from specific LLM vendors.
- **Config**: Supported `GEMINI_API_KEY`, `GEMINI_MODEL`, and `GEMINI_BASE_URL` via environment variables.

## 📦 Package Changes
- Added `reqwest` (v0.12) with `json` feature to workspace dependencies.
- Added `mockito` (v1.4) to workspace dev-dependencies for API mocking.

## 🧪 Reviewer Testing Guide

### Automated Tests to Run
- [x] `cargo test -p mailsense-core --lib llm::tests` (Verifies Gemini response parsing)
- [x] `cargo test --workspace` (Full suite regression)

### Manual Verification
You can now test the real LLM integration using the provided example script:

1. Create or update your `.env` file with a valid Gemini API Key:
   ```bash
   GEMINI_API_KEY=your_actual_api_key_here
   ```
2. Run the manual integration test:
   ```bash
   cargo run -p mailsense-core --example llm_test
   ```
3. Verify the output displays the correct **Intent**, **Tags**, and **Summary** for the sample email.